### PR TITLE
golang-http2 to v0.0.7

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -10,3 +10,6 @@ dependencies:
 - name: golang-http
   repository: http://jenkins-x-chartmuseum:8080
   version: v0.0.2
+- name: golang-http2
+  repository: http://jenkins-x-chartmuseum:8080
+  version: v0.0.7


### PR DESCRIPTION
Promote golang-http2 to version v0.0.7